### PR TITLE
Updated the About page link

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
                         <a href="#">home</a>
                     </li>
                     <li>
-                        <a href="./about.html">about</a>
+                        <a href="./About.html">about</a>
                     </li>
                     <li>
                         <a href="./contact.html">contact us</a>


### PR DESCRIPTION
The about link was previously `./about` rather than `./About`